### PR TITLE
Strip comments from included JSON files

### DIFF
--- a/dfwfw/PreJSON/PreJSON.pm
+++ b/dfwfw/PreJSON/PreJSON.pm
@@ -22,6 +22,7 @@ sub decode {
          for my $f (glob $v) {
             $re .= read_file($f);
          }
+         $re =~ s/#.*//g;  # strip out comments
          return $re || "";
      }
 


### PR DESCRIPTION
Without this commit, comments with leading # are supported in the main
configuration file, but not any JSON includes as they are not stripped
by the JSON preprocessor.
